### PR TITLE
Fix scroll overlap with sidebar

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -6,7 +6,7 @@ const Sidebar = () => {
   const { isAuthenticated } = useAuthStore();
 
   return (
-    <aside className="bg-gray-800 border border-gray-700 rounded-2xl p-4 h-[calc(100vh-112px)] sticky top-4 flex flex-col">
+    <aside className="bg-gray-800 border border-gray-700 rounded-2xl p-4 h-full flex flex-col">
       <div className="flex items-center gap-3 mb-4">
         <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-green-500 to-cyan-400 flex items-center justify-center text-black font-extrabold text-lg">
           ♪

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -24,20 +24,22 @@ const Dashboard = () => {
   const showFeatured = location.pathname === "/";
 
   return (
-    <div className="bg-gray-900 text-white min-h-screen flex flex-col">
+    <div className="bg-gray-900 text-white h-screen flex flex-col overflow-hidden">
       {/* Grid gồm 2 cột: Sidebar + Main */}
       <div className="flex flex-1 overflow-hidden">
         {/* Sidebar cố định 240px */}
-        <Sidebar className="w-60 flex-shrink-0" />
+        <div className="w-60 flex-shrink-0 p-4">
+          <Sidebar className="w-full h-full" />
+        </div>
 
         {/* Main chiếm toàn bộ phần còn lại */}
-        <main className="flex-1 flex flex-col bg-gray-800 border border-gray-700 rounded-2xl m-4 overflow-hidden">
+        <main className="flex-1 flex flex-col bg-gray-800 border border-gray-700 rounded-2xl m-4 ml-0 overflow-hidden">
           {/* Topbar */}
-          <div className="p-4 border-b border-gray-700">
+          <div className="p-4 border-b border-gray-700 flex-shrink-0">
             <Topbar />
           </div>
 
-          {/* Nội dung (Outlet) chiếm toàn bộ chiều cao còn lại */}
+          {/* Nội dung (Outlet) chiếm toàn bộ chiều cao còn lại với scroll riêng */}
           <div className="flex-1 overflow-y-auto p-4">
             <Outlet />
 


### PR DESCRIPTION
Refactor Dashboard and Sidebar layouts to confine scrolling to the main content area.

This change prevents the page scrollbar from overlapping the sidebar, ensuring the sidebar remains fixed and only the main content area scrolls.

---
<a href="https://cursor.com/background-agent?bcId=bc-fedd281e-7fb0-4490-a92f-b898886968ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fedd281e-7fb0-4490-a92f-b898886968ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

