### PR TITLE
Fix scroll overlap with sidebar

### DIFF
--- a/src/components/PlayLists/PLayLists.jsx
+++ b/src/components/PlayLists/PLayLists.jsx
@@ -81,7 +81,7 @@ const PlayLists = () => {
   };
 
   return (
-    <div className="min-h-screen w-full bg-[#121212] p-6 text-white font-sans">
+    <div className="min-h-full w-full bg-[#121212] p-6 text-white font-sans">
       {/* Header */}
       <header className="flex items-center justify-between mb-8">
         <h1 className="text-3xl font-bold tracking-tight">Your Playlists</h1>

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -2,11 +2,11 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { useAuthStore } from "../../store/auth";
 
-const Sidebar = () => {
+const Sidebar = ({ className = "" }) => {
   const { isAuthenticated } = useAuthStore();
 
   return (
-    <aside className="bg-gray-800 border border-gray-700 rounded-2xl p-4 h-[calc(100vh-112px)] sticky top-4 flex flex-col">
+    <aside className={`bg-gray-800 border border-gray-700 rounded-2xl p-4 h-[calc(100vh-112px)] sticky top-4 flex flex-col ${className}`}>
       <div className="flex items-center gap-3 mb-4">
         <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-green-500 to-cyan-400 flex items-center justify-center text-black font-extrabold text-lg">
           ♪

--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,7 @@ body {
   height: 100%;
   display: block; /* bỏ flex căn giữa */
   background-color: #111827; /* cùng tone với bg-gray-900 */
+  overflow: hidden; /* ngăn body scroll ăn vào sidebar */
 }
 
 

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -24,7 +24,7 @@ const Dashboard = () => {
   const showFeatured = location.pathname === "/";
 
   return (
-    <div className="bg-gray-900 text-white min-h-screen flex flex-col">
+    <div className="bg-gray-900 text-white h-screen overflow-hidden flex flex-col">
       {/* Grid gồm 2 cột: Sidebar + Main */}
       <div className="flex flex-1 overflow-hidden">
         {/* Sidebar cố định 240px */}
@@ -38,7 +38,7 @@ const Dashboard = () => {
           </div>
 
           {/* Nội dung (Outlet) chiếm toàn bộ chiều cao còn lại */}
-          <div className="flex-1 overflow-y-auto p-4">
+          <div className="flex-1 overflow-y-auto p-4 pb-28">
             <Outlet />
 
             {showFeatured && (


### PR DESCRIPTION
Adjust scrolling behavior to prevent content from overlapping the sidebar.

The previous layout allowed the `body` to scroll, causing the main content area to scroll under the fixed sidebar. This PR fixes the layout by constraining the main content to its own scrollable area and disabling global body scrolling.

---
<a href="https://cursor.com/background-agent?bcId=bc-c53cebc9-88cc-4fa3-ab6d-de7101a7d71c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c53cebc9-88cc-4fa3-ab6d-de7101a7d71c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

